### PR TITLE
epub:type="rearnotes" → epub:type="endnotes"

### DIFF
--- a/src/epub/text/endnotes.xhtml
+++ b/src/epub/text/endnotes.xhtml
@@ -9,10 +9,10 @@
 		<section id="endnotes" epub:type="endnotes">
 			<h2 epub:type="title">Endnotes</h2>
 			<ol>
-				<li id="note-1" epub:type="rearnote">
+				<li id="note-1" epub:type="endnote">
 					<p><abbr>Cf.</abbr> <abbr class="name">A. N.</abbr> Whitehead, <i epub:type="se:name.publication.book">Introduction to Mathematics</i> (Home University Library). <a href="chapter-7.xhtml#noteref-1" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-2" epub:type="rearnote">
+				<li id="note-2" epub:type="endnote">
 					<p>Kant’s “thing in itself” is identical in “definition” with the physical object, namely, it is the cause of sensations. In the properties deduced from the definition it is not identical, since Kant held (in spite of some inconsistency as regards cause) that we can know that none of the categories are applicable to the “thing in itself.” <a href="chapter-8.xhtml#noteref-2" epub:type="backlink">↩</a></p>
 				</li>
 			</ol>

--- a/src/epub/text/endnotes.xhtml
+++ b/src/epub/text/endnotes.xhtml
@@ -6,7 +6,7 @@
 		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
 	</head>
 	<body epub:type="backmatter z3998:fiction">
-		<section id="endnotes" epub:type="rearnotes">
+		<section id="endnotes" epub:type="endnotes">
 			<h2 epub:type="title">Endnotes</h2>
 			<ol>
 				<li id="note-1" epub:type="rearnote">

--- a/src/epub/toc.xhtml
+++ b/src/epub/toc.xhtml
@@ -99,7 +99,7 @@
 					<a href="text/chapter-1.xhtml" epub:type="bodymatter z3998:non-fiction">The Problems of Philosophy</a>
 				</li>
 				<li>
-					<a href="text/endnotes.xhtml" epub:type="backmatter rearnotes">Endnotes</a>
+					<a href="text/endnotes.xhtml" epub:type="backmatter endnotes">Endnotes</a>
 				</li>
 				<li>
 					<a href="text/bibliographical-note.xhtml" epub:type="backmatter bibliography">Bibliographical Note</a>


### PR DESCRIPTION
[`rearnotes` is deprecated in favor of `endnotes`.](https://idpf.github.io/epub-vocabs/structure/#notes)